### PR TITLE
change default http_address attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['monit']['monitrc']['eventqueue']   = "basedir /var/monit/ slots 1000"
 
 
 default['monit']['monitrc']['http_port']   = "2812"
-default['monit']['monitrc']['http_address']   = "0.0.0.0"
+default['monit']['monitrc']['http_address']   = node['ipaddress']
 default['monit']['monitrc']['allows']   = ["localhost"]
 
 


### PR DESCRIPTION
set default http_address attribute to node's ipaddress, this is very useful if you use m/monit, node gets automatically registered with m/monit and up and running without any additional settings. 
