### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,6 +43,7 @@ end
 
 template "/etc/monitrc" do
   source "monitrc.erb"
+  mode "0700"
   variables node['monit']['monitrc']
   notifies :restart, "service[monit]"
 end


### PR DESCRIPTION
This change can wake monit up as service.
(Resolve permission problem - it can not wake up with go+r)
