### PR TITLE
Update README.md with correct cookbook name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Put your confing to `/etc/monit/conf.avail/` and...
 
 ** To enable setting**
 
-    monitensite postfix.conf  
+    monitensite postfix.conf
     monit reload
 
 ** To disable setting**


### PR DESCRIPTION
It looks like this section of the README was copied from the monit_binaries cookbook and not updated.
