### PR TITLE
New monit version released: 5.14

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['monit']['version'] = "5.11"
+default['monit']['version'] = "5.14"
 
 case node['kernel']['machine']
   when "x86_64" then


### PR DESCRIPTION
The older binaries have been removed, so this cookbook's broken until the version's updated.
